### PR TITLE
Issue #24 Resolved, Improved form validation in Registration page

### DIFF
--- a/app/src/main/java/com/appteam/nimbus/Registar.java
+++ b/app/src/main/java/com/appteam/nimbus/Registar.java
@@ -161,17 +161,17 @@ PersonalData personalData;
 
             @Override
             public void afterTextChanged(Editable editable) {
-                if(!Patterns.PHONE.matcher(phoneno.getText().toString()).matches()){
-                    phonenoTextInputLayout.setError("NOT VALID PHONE NUMBER");
-                    isphone=false;
-                }
-                else {
-    phonenoTextInputLayout.setErrorEnabled(false);
-    isphone=true;
+        if(phoneno.getText().toString().length()==10){
+        phonenoTextInputLayout.setErrorEnabled(false);
+        isphone=true;
+        } else {
+        phonenoTextInputLayout.setError("NOT VALID PHONE NUMBER");
+        isphone=false;
 }
             }
         });
     }
+
 
     private void sendRequest(String string, String string1,String string2,String string3,boolean nitian) {
         Map<String,String> params=new HashMap<String, String>();


### PR DESCRIPTION
Earlier, while validating our entered contact number in the contact input field of new registration activity page, it was showing our number to be a **valid number** on entering **3rd digit**. since, any registered mobile number must be of exactly **10 digits**. so, replaced the matches() function by conditional check and enhanced the validation feature. :)
